### PR TITLE
Add Paycom

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6448,6 +6448,11 @@
             "guidelines": "https://www.patreon.com/brand/downloads"
         },
         {
+            "title": "Paycom",
+            "hex": "00843A",
+            "source": "https://www.paycom.com/"
+        }
+        {
             "title": "Payoneer",
             "hex": "FF4800",
             "source": "https://www.payoneer.com/"


### PR DESCRIPTION
![paycom](https://user-images.githubusercontent.com/73037261/121906994-a3164200-ccf9-11eb-82f8-0cddfc379db8.png)

**Issue:** #5945
**Alexa rank:** 29,042

### Checklist
  - [ ] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
I tried to vectorize the SVG icon of Paycom, and just wrote on SVG-edit, and the color of this brand Paycom is `#00843a`.
